### PR TITLE
Only segment new images

### DIFF
--- a/src/acmpc/perception/observations.py
+++ b/src/acmpc/perception/observations.py
@@ -16,6 +16,7 @@ class ObservationDict(dict):
         self["CameraFrontSegm"] = masks[0]
 
     def _setup(self, obs: Dict):
+        self["is_image_stale"] = obs["is_image_stale"]
         self["CameraFrontRGB"] = obs["image"]
         pose = self._unpack_pose(obs["state"])
         self["speed"] = pose["velocity"]

--- a/src/acmpc/perception/perception.py
+++ b/src/acmpc/perception/perception.py
@@ -58,8 +58,9 @@ class Perceiver:
         return self._perceiver.output_visualisation
 
     def perceive(self, obs: ObservationDict):
-        self._preprocess_observations(obs)
-        self._submit_image_to_perceiver(obs)
+        if not obs["is_image_stale"]:
+            self._preprocess_observations(obs)
+            self._submit_image_to_perceiver(obs)
 
     def _preprocess_observations(self, obs: ObservationDict):
         obs["CameraFrontRGB"] = self._encode_decode_image(obs["CameraFrontRGB"])


### PR DESCRIPTION
Now that ACI provides the `is_stale_image` flag this is used so that only fresh captures are submitted to the segmentation model for processing improving iteration speed.